### PR TITLE
fix: Hard code additional_css and avoid use of html_safe

### DIFF
--- a/app/views/settings/_redmine_sudo_settings.html.erb
+++ b/app/views/settings/_redmine_sudo_settings.html.erb
@@ -8,9 +8,3 @@
   <%= text_field_tag 'settings[become_user]', @settings['become_user'] %>
 </p>
 </fieldset>
-<fieldset>
-<p>
-  <label><%= l(:css_admin_label) %></label>
-  <%= text_area_tag 'settings[additional_css]', @settings['additional_css'], :size => '50x5' %>
-</p>
-</fieldset>

--- a/app/views/sudo/_sudo_styles.html.erb
+++ b/app/views/sudo/_sudo_styles.html.erb
@@ -1,7 +1,12 @@
 <style>
   #top-menu #sudo_id { margin: 0 8px 0 -8px; }
-<% if User.current.admin? && Setting.plugin_redmine_sudo["additional_css"].present? %>
-  <%= Setting.plugin_redmine_sudo["additional_css"].html_safe %>
-<% end %>
+  <% if User.current.admin? %>
+  #top-menu { background-color: #BA0C04; }
+  #header { background-color: #dd0037 !important; background-image: none; }
+  #main-menu li a { background-color: #BA0C04; }
+  #main-menu li a.new-object { background-color: #BA0C04; }
+  #main-menu li a:hover { background-color: #8D0A02; }
+  @media all and (max-width: 899px) { #header { background-color: #dd0037 !important; } }
+  <% end %>
   body.controller-users table.list td.tick.sudoer { opacity:0.4; }
 </style>

--- a/init.rb
+++ b/init.rb
@@ -18,24 +18,18 @@ Redmine::Plugin.register :redmine_sudo do
   Redmine::MenuManager.map :account_menu do |menu|
     menu.push :sudo, :sudo_toggle_path,
               html: { method: 'get',
-                      id: "sudo_id" },
+                      id: 'sudo_id' },
               caption: proc {
-                Setting.plugin_redmine_sudo[User.current.admin? ? "become_user" : "become_admin"]
+                Setting.plugin_redmine_sudo[User.current.admin? ? 'become_user' : 'become_admin']
               },
               before: :my_account,
-              class: "sudo",
+              class: 'sudo',
               if: proc { User.current.sudoer? }
   end
 
   settings default: {
-             'become_admin' => '[sudo -v]',
-    'become_user' => '[sudo -k]',
-    'additional_css' => "#top-menu { background-color:#BA0C04; }\n
-                        #header { background-color:#dd0037; }\n
-                        #main-menu li a { background-color:#BA0C04; }\n
-                        #main-menu li a.new-object { background-color:#BA0C04; }\n
-                        #main-menu li a:hover { background-color:#8D0A02; }\n
-                        @media all and (max-width: 899px) { #header{ background-color: #dd0037 !important; }"
+             'become_admin' => 'Become Admin',
+             'become_user' => 'Become User'
            },
            partial: 'settings/redmine_sudo_settings'
 end


### PR DESCRIPTION
Avoid the use of html_safe (security risk):
- Use a hard coded style for the additional css on sudo-ing (background-image: none is for overriding redmine 6.1 gradient).
- Remove the additional css setting.
