### PR TITLE
fix: Keep redmine native semantics for admin and treat sudoer as active admin flag

### DIFF
--- a/app/controllers/sudo_controller.rb
+++ b/app/controllers/sudo_controller.rb
@@ -1,8 +1,8 @@
 class SudoController < ApplicationController
   def toggle
     require_login # should render a 403 if no user found
-    if User.current.sudoer?
-      User.current.update_admin!(!User.current.admin?)
+    if User.current.permanent_admin?
+      User.current.update_sudoer!(!User.current.sudoer?)
 
       params[:back_url] = url_for(request.referer) if request.referer.present?
       redirect_back_or_default controller: "my", action: "page"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2,4 +2,4 @@ de:
   become_admin_label: 'Benutzer->Administrator'
   become_user_label: 'Administrator->Benutzer'
   css_admin_label: CSS-Regeln Administrator
-  field_sudoer: Sudoer
+  field_sudoer: Aktiver Administrator

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,4 +2,4 @@ en:
   become_admin_label: 'User->Admin'
   become_user_label: 'Admin->User'
   css_admin_label: CSS rules Admin
-  field_sudoer: Sudoer
+  field_sudoer: Active Admin

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2,4 +2,4 @@ es:
   become_admin_label: 'Usuario->Administrador'
   become_user_label: 'Administrador->Usuario'
   css_admin_label: Reglas CSS Administrador
-  field_sudoer: Sudoer
+  field_sudoer: Administrador Activo

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2,4 +2,4 @@ fr:
   become_admin_label: 'Utilisateur->Administrateur'
   become_user_label: 'Administrateur->Utilisateur'
   css_admin_label: Règles CSS de l'administrateur
-  field_sudoer: Sudoer
+  field_sudoer: Administrateur Actif

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -2,4 +2,4 @@ nl:
   become_admin_label: 'Gebruiker->Beheerder'
   become_user_label: 'Beheerder->Gebruiker'
   css_admin_label: CSS-regels voor beheerder
-  field_sudoer: Sudoer
+  field_sudoer: Actieve Beheerder

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -2,4 +2,4 @@ ru:
   become_admin_label: 'Пользователь->Администратор'
   become_user_label: 'Администратор->Пользователь'
   css_admin_label: CSS Администратор
-  field_sudoer: Sudoer
+  field_sudoer: Активный Администратор

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -2,4 +2,4 @@ tr:
   become_admin_label: 'Kullanıcı->Yönetici'
   become_user_label: 'Yönetici->Kullanıcı'
   css_admin_label: CSS kuralları Yönetici
-  field_sudoer: Sudoer
+  field_sudoer: Aktif Yönetici

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 RedmineApp::Application.routes.draw do
-  match 'sudo/toggle', to: 'sudo#toggle', as: 'sudo_toggle', via: [:get, :post]
+  post 'sudo/toggle', to: 'sudo#toggle', as: 'sudo_toggle'
 end

--- a/db/migrate/002_swap_admin_sudoer_semantics.rb
+++ b/db/migrate/002_swap_admin_sudoer_semantics.rb
@@ -1,0 +1,17 @@
+class SwapAdminSudoerSemantics < ActiveRecord::Migration[7.2]
+  def self.up
+    add_column :users, :_admin_tmp, :boolean, default: false, null: false
+    execute "UPDATE users SET _admin_tmp = sudoer"
+    execute "UPDATE users SET sudoer = admin"
+    execute "UPDATE users SET admin = _admin_tmp"
+    remove_column :users, :_admin_tmp
+  end
+
+  def self.down
+    add_column :users, :_admin_tmp, :boolean, default: false, null: false
+    execute "UPDATE users SET _admin_tmp = sudoer"
+    execute "UPDATE users SET sudoer = admin"
+    execute "UPDATE users SET admin = _admin_tmp"
+    remove_column :users, :_admin_tmp
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -17,7 +17,7 @@ Redmine::Plugin.register :redmine_sudo do
 
   Redmine::MenuManager.map :account_menu do |menu|
     menu.push :sudo, :sudo_toggle_path,
-              html: { method: 'get',
+              html: { method: 'post',
                       id: 'sudo_id' },
               caption: proc {
                 Setting.plugin_redmine_sudo[User.current.admin? ? 'become_user' : 'become_admin']

--- a/init.rb
+++ b/init.rb
@@ -24,7 +24,7 @@ Redmine::Plugin.register :redmine_sudo do
               },
               before: :my_account,
               class: 'sudo',
-              if: proc { User.current.sudoer? }
+              if: proc { User.current.permanent_admin? }
   end
 
   settings default: {

--- a/lib/redmine_sudo/user_patch.rb
+++ b/lib/redmine_sudo/user_patch.rb
@@ -3,20 +3,35 @@ require_dependency 'principal'
 require_dependency 'user'
 
 module RedmineSudo::UserPatch
-  def update_sudoer
-    if new_record? || admin? || admin_changed?
-      self.sudoer = self.admin
+  # Override admin? to reflect the toggled sudoer state.
+  # All Redmine permission checks (allowed_to?, safe_attributes, API output)
+  # will use this, so toggling sudoer on/off controls active admin privileges.
+  def admin?
+    self.sudoer?
+  end
+
+  # Returns the permanent admin flag from the DB column,
+  # unaffected by the sudo toggle.
+  def permanent_admin?
+    read_attribute(:admin)
+  end
+
+  # Syncs sudoer to match admin when the admin flag is granted/revoked or on creation.
+  def sync_sudoer
+    if new_record? || admin_changed?
+      self.sudoer = read_attribute(:admin)
     end
     true
   end
 
-  def update_admin!(value)
-    User.where(id: self.id).update_all(admin: value)
+  # Toggles the sudoer (active admin) flag without triggering callbacks.
+  def update_sudoer!(value)
+    User.where(id: self.id).update_all(sudoer: value)
     User.where(id: self.id).update_all(updated_on: Time.now)
   end
 end
 
 class User < Principal
-  include RedmineSudo::UserPatch
-  before_save :update_sudoer
+  prepend RedmineSudo::UserPatch
+  before_save :sync_sudoer
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -13,43 +13,47 @@ describe UsersController, type: :controller do
     User.current = nil
     @request.session = ActionController::TestSession.new
     @request.session[:user_id] = 1 # permissions admin
+    User.find(1).update_columns(sudoer: true) # ensure admin? returns true
   end
 
   describe "POST update" do
-    it "gives both sudoer and admin roles when selecting the option in user form" do
-      user_7.update_attribute(:admin, false)
-      expect(user_7).to_not be_admin
-      expect(user_7).to_not be_sudoer
+    it "gives both admin and sudoer when selecting admin in user form" do
+      user_7.update_columns(admin: false, sudoer: false)
+      user_7.reload
+      expect(user_7.read_attribute(:admin)).to eq false
+      expect(user_7.sudoer?).to eq false
 
       patch :update, :params => { :id => 7, :user => { admin: '1', mail: "test7@example.net" } }
 
       user_7.reload
-      expect(user_7).to be_admin
-      expect(user_7).to be_sudoer
+      expect(user_7.read_attribute(:admin)).to eq true
+      expect(user_7.sudoer?).to eq true
     end
 
-    it "removes both sudoer and admin roles when deselecting the option in user form" do
-      user_7.update_attribute(:admin, true)
-      expect(user_7).to be_admin
-      expect(user_7).to be_sudoer
+    it "removes both admin and sudoer when deselecting admin in user form" do
+      user_7.update_columns(admin: true, sudoer: true)
+      user_7.reload
+      expect(user_7.read_attribute(:admin)).to eq true
+      expect(user_7.sudoer?).to eq true
 
       patch :update, :params => { :id => 7, :user => { admin: '0', mail: "test7@example.net" } }
 
       user_7.reload
-      expect(user_7).to_not be_admin
-      expect(user_7).to_not be_sudoer
+      expect(user_7.read_attribute(:admin)).to eq false
+      expect(user_7.sudoer?).to eq false
     end
 
-    it "removes both sudoer and admin roles even when user is not currently admin" do
-      user_7.update(admin: false, sudoer: true)
-      expect(user_7).to_not be_admin
-      expect(user_7).to be_sudoer
+    it "removes both admin and sudoer even when user is not currently sudoed" do
+      user_7.update_columns(admin: true, sudoer: false)
+      user_7.reload
+      expect(user_7.read_attribute(:admin)).to eq true
+      expect(user_7.sudoer?).to eq false
 
       patch :update, :params => { :id => 7, :user => { admin: '0', mail: "test7@example.net" } }
 
       user_7.reload
-      expect(user_7).to_not be_admin
-      expect(user_7).to_not be_sudoer
+      expect(user_7.read_attribute(:admin)).to eq false
+      expect(user_7.sudoer?).to eq false
     end
   end
 

--- a/spec/features/sudo_spec.rb
+++ b/spec/features/sudo_spec.rb
@@ -21,21 +21,34 @@ describe "Sudo", type: :request do
       )
     end
 
-    it "should toggle sudo rights" do
+    it "should toggle sudoer without changing admin" do
       user = User.find_by_login("admin")
-      user.update_attribute(:sudoer, true)
+      user.update_columns(admin: true, sudoer: true)
       log_user("admin", "admin")
 
-      assert user.reload.admin?
+      assert user.reload.read_attribute(:admin)
       assert user.reload.sudoer?
 
       post "/sudo/toggle", params: { back_url: "/my/page" }
       expect(response).to redirect_to("/my/page")
-      assert !user.reload.admin?
+      user.reload
+      assert user.read_attribute(:admin), "admin column should remain true"
+      assert !user.sudoer?, "sudoer should be toggled off"
 
       post "/sudo/toggle", params: { back_url: "/my/page" }
       expect(response).to redirect_to("/my/page")
-      assert user.reload.admin?
+      user.reload
+      assert user.read_attribute(:admin), "admin column should still remain true"
+      assert user.sudoer?, "sudoer should be toggled back on"
+    end
+
+    it "should deny toggle to non-permanent-admin" do
+      user = User.find_by_login("jsmith")
+      user.update_columns(admin: false, sudoer: false)
+      log_user("jsmith", "jsmith")
+
+      post "/sudo/toggle", params: { back_url: "/my/page" }
+      expect(response).to have_http_status(403)
     end
 
     it "should not allow a redirection to a different domain name" do

--- a/spec/features/sudo_spec.rb
+++ b/spec/features/sudo_spec.rb
@@ -16,7 +16,7 @@ describe "Sudo", type: :request do
   context "toggle link" do
     it "should route to sudo#toggle" do
       assert_routing(
-        { method: :get, path: "/sudo/toggle" },
+        { method: :post, path: "/sudo/toggle" },
         { controller: "sudo", action: "toggle" }
       )
     end
@@ -29,17 +29,17 @@ describe "Sudo", type: :request do
       assert user.reload.admin?
       assert user.reload.sudoer?
 
-      get "/sudo/toggle?back_url=/my/page"
+      post "/sudo/toggle", params: { back_url: "/my/page" }
       expect(response).to redirect_to("/my/page")
       assert !user.reload.admin?
 
-      get "/sudo/toggle?back_url=/my/page"
+      post "/sudo/toggle", params: { back_url: "/my/page" }
       expect(response).to redirect_to("/my/page")
       assert user.reload.admin?
     end
 
     it "should not allow a redirection to a different domain name" do
-      get "/sudo/toggle?back_url=.my-custom-domain-name.com"
+      post "/sudo/toggle", params: { back_url: ".my-custom-domain-name.com" }
       expect(response).to_not redirect_to("my-custom-domain-name.com")
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,36 +18,72 @@ unless User.respond_to?(:generate)
 end
 
 describe 'User' do
-  it 'should user gets correct sudoer at creation' do
+  it 'should set sudoer=true when creating an admin user' do
     user = User.generate(admin: true)
     expect(user.sudoer?).to eq true
+    expect(user.read_attribute(:admin)).to eq true
+  end
+
+  it 'should set sudoer=false when creating a non-admin user' do
     user = User.generate(admin: false)
+    expect(user.sudoer?).to eq false
+    expect(user.read_attribute(:admin)).to eq false
+  end
+
+  it 'should keep admin unchanged when toggling sudoer via update_sudoer!' do
+    user = User.generate(admin: true)
+    user.update_sudoer!(false)
+    user.reload
+    expect(user.read_attribute(:admin)).to eq true
     expect(user.sudoer?).to eq false
   end
 
-  it 'should user keeps sudoer on update if he should' do
+  it 'admin? should return the sudoer value (toggled state)' do
     user = User.generate(admin: true)
-    user.update_admin!(false)
-    expect(user.reload.sudoer?).to eq true
-    # doesn't change #admin, so #sudoer doesn't change
-    user.update_attribute(:firstname, 'John')
-    expect(user.reload.sudoer?).to eq true
+    expect(user.admin?).to eq true
+
+    user.update_sudoer!(false)
+    user.reload
+    expect(user.admin?).to eq false
+
+    user.update_sudoer!(true)
+    user.reload
+    expect(user.admin?).to eq true
   end
 
-  it 'should user gets correct sudoer when updating admin boolean' do
+  it 'permanent_admin? should return the raw admin column' do
     user = User.generate(admin: true)
-    # updates #admin, so #sudoer should be updated accordingly
+    user.update_sudoer!(false)
+    user.reload
+    expect(user.permanent_admin?).to eq true
+    expect(user.admin?).to eq false
+  end
+
+  it 'should not change sudoer on unrelated attribute updates' do
+    user = User.generate(admin: true)
+    user.update_sudoer!(false)
+    user.reload
+    expect(user.sudoer?).to eq false
+    # unrelated update should not re-sync sudoer
+    user.update_attribute(:firstname, 'John')
+    expect(user.reload.sudoer?).to eq false
+  end
+
+  it 'should sync sudoer when admin flag is changed via save' do
+    user = User.generate(admin: true)
+    # revoke admin → sudoer should be cleared
     user.update_attribute(:admin, false)
     expect(user.reload.sudoer?).to eq false
+    # grant admin → sudoer should be set
     user.update_attribute(:admin, true)
     expect(user.reload.sudoer?).to eq true
   end
 
-  it 'should #update_admin! sets a new updated_on date after admin changed' do
+  it 'should #update_sudoer! sets a new updated_on date' do
     user = User.generate(admin: true)
     user.update_attribute(:updated_on, nil)
     expect(user.reload.updated_on).to eq nil
-    user.update_admin!(false)
+    user.update_sudoer!(false)
     refute_nil user.reload.updated_on
   end
 end


### PR DESCRIPTION
The `redmine_sudo` plugin degraded the built-in `admin` column to mean "currently active admin" and uses `sudoer` as the permanent admin flag. This is backwards — it breaks Redmine's admin user listings, makes admin removal confusing, and leaves the DB in a bad state if the plugin is ever removed. The fix inverts the semantics: `admin` stays the permanent admin flag (Redmine's native meaning), and `sudoer` becomes the toggle for "currently acting as admin". This requires overriding `admin?` to check `sudoer`, rewriting the toggle to flip `sudoer` instead of `admin`, a data migration that swaps existing values.

Also switch from GET to POST for the toggle:

The former `toggle` used `GET` (CSRF risk for state change).
Changed to `POST` - More secure
